### PR TITLE
Set $_ret to $rc ("2") when "$rc" = "$RENEW_SKIP"

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4400,6 +4400,7 @@ renewAll() {
     if [ "$rc" != "0" ]; then
       if [ "$rc" = "$RENEW_SKIP" ]; then
         _info "Skipped $d"
+        _ret="$rc"
       elif [ "$_stopRenewOnError" ]; then
         _err "Error renew $d,  stop now."
         return "$rc"


### PR DESCRIPTION
$_ret is set to 0 above and is not set to 2 on "Skipped".  Script exits with return code 0 when it should be 2.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->